### PR TITLE
Spinners

### DIFF
--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'json'
+require 'tmpdir'
 require 'tty/platform'
 require 'xcodeproj'
 require_relative 'util'
@@ -82,9 +83,9 @@ module ReactNativeUtil
         exit 1
       end
 
-      # Don't run yarn until we're sure we're proceeding,
+      # Don't run yarn until we're sure we're proceeding.
       log 'Installing NPM dependencies with yarn'
-      execute 'yarn'
+      run_command_with_spinner 'yarn', log: File.join(Dir.tmpdir, 'yarn.log')
 
       # Unused, but should be there and parseable
       load_react_podspec!
@@ -125,9 +126,9 @@ module ReactNativeUtil
       end
 
       # 7. pod install
-      command = %w[pod install --silent]
+      command = %w[pod install]
       command << '--repo-update' if options[:repo_update]
-      execute(*command, chdir: 'ios')
+      run_command_with_spinner(*command, chdir: 'ios', log: File.join(Dir.tmpdir, 'pod-install.log'))
 
       # 8. SCM/git (add, commit - optional)
 

--- a/react_native_util.gemspec
+++ b/react_native_util.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colored', '~> 1.2'
   spec.add_dependency 'commander', '~> 4.4'
   spec.add_dependency 'tty-platform', '~> 0.2'
+  spec.add_dependency 'tty-spinner', '~> 0.9'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'pry', '~> 0.12'


### PR DESCRIPTION
Use tty-spinner to display a spinner when running any command that generates output to the screen or takes time. Output is redirected to a file in `Dir.tmpdir`. The appropriate log path is reported in case of error.

```
2019-05-11T10:34:08-07:00 package.json:
2019-05-11T10:34:08-07:00  app name: "TestApp"
2019-05-11T10:34:08-07:00 Found Xcode project at ~/sandbox/TestApp/ios/TestApp.xcodeproj
2019-05-11T10:34:08-07:00 Installing NPM dependencies with yarn
[✔] yarn success
2019-05-11T10:34:09-07:00 Dependencies:
2019-05-11T10:34:09-07:00  react-native-webview
2019-05-11T10:34:09-07:00 Unlinking dependencies
[✔] react-native unlink react-native-webview success
2019-05-11T10:34:10-07:00 Removing Libraries from TestApp
2019-05-11T10:34:10-07:00 Removing Libraries from TestAppTests
2019-05-11T10:34:10-07:00 Removing Libraries group
2019-05-11T10:34:10-07:00 Generating ios/Podfile
2019-05-11T10:34:10-07:00 Linking dependencies
[✔] react-native link react-native-webview success
2019-05-11T10:34:10-07:00 Generating Pods project and ios/TestApp.xcworkspace
[✔] pod install success
2019-05-11T10:34:19-07:00 Conversion complete ✅
2019-05-11T10:34:19-07:00 $ open ios/TestApp.xcworkspace
```