### PR TITLE
Update project

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,35 @@ rn -h
 rn react_pod -h
 ```
 
+## react_pod command
+
+Converts a React Native Xcode project to use the React pod from node_modules
+instead of the projects in the Libraries group. This makes it easier to manage
+native dependencies while preserving compatibility with `react-native link`.
+The command looks for your app's package.json in the current directory and
+expects your Xcode project to be located under the ios subdirectory and have
+the name specified for your app in package.json. If a Podfile is found in the
+ios subdirectory, the conversion will fail.
+
+The React.xcodeproj in the Libraries group of a project created by
+`react-native init` automatically starts the Metro packager via a Run Script
+build phase. When the react_pod command removes the Libraries group from your
+app project, it adds an equivalent build phase to your app project so that the
+packager will automatically be started when necessary by Xcode.
+
+Use the `-u` or `--update` option to update the packager script after
+updating React Native, in case the packager script on the React.xcodeproj changes
+after it's removed from your project.
+
+### Options
+
+|option|description|env. var.|
+|------|-----------|---------|
+|-h, --help|Print command help||
+|-t, --trace|Print a stack trace in case of error||
+|-u, --update|Update a previously converted project||
+|--[no-]repo-update|Don't update the local podspec repo|REACT_NATIVE_UTIL_REPO_UPDATE|
+
 ## Try it out
 
 Convert examples/TestApp.
@@ -151,6 +180,7 @@ require 'react_native_util/rake'
 ReactNativeUtil::Rake::ReactPodTask.new(
   :react_pod,                         # task name
   'Convert project to use React pod', # description
+  'Update project',                   # description for :update task
   chdir: '/path/to/rn/project',       # path to project package.json
   repo_update: true                   # optionally disable pod repo update
 )
@@ -161,6 +191,16 @@ Override `chdir` at the command line:
 rake react_pod[/path/to/another/rn/project]
 ```
 
+Convert project:
+```bash
+rake react_pod
+```
+
+Update converted project:
+```bash
+rake react_pod:update
+```
+
 ## Ruby script
 
 ```Ruby
@@ -168,7 +208,13 @@ require 'react_native_util/converter'
 
 Dir.chdir '/path/to/rn/project' do
   begin
-    ReactNativeUtil::Converter.new(repo_update: true).convert_to_react_pod!
+    converter = ReactNativeUtil::Converter.new(repo_update: true)
+
+    # Convert a project to use the React pod
+    converter.convert_to_react_pod!
+
+    # Update a converted project
+    converter.update_project!
   rescue ReactNativeUtil::BaseException => e
     puts "Error from #convert_to_react_pod!: #{e.message}"
   end

--- a/lib/react_native_util/cli.rb
+++ b/lib/react_native_util/cli.rb
@@ -27,12 +27,17 @@ automatically via a Run Script build phase in the Xcode project. This is an
 alternative to performing manual surgery on a project in Xcode.
 DESC
 
+        c.option '-u', '--[no-]update', 'Update a previously converted project (default: convert)'
         c.option '--[no-]repo-update', 'Update the local podspec repo (default: update; env. var. REACT_NATIVE_UTIL_REPO_UPDATE)'
 
         c.action do |_args, opts|
           begin
             converter = Converter.new repo_update: opts.repo_update
-            converter.convert_to_react_pod!
+            if opts.update
+              converter.update_project!
+            else
+              converter.convert_to_react_pod!
+            end
             exit 0
           rescue ExecutionError => e
             # Generic command failure.

--- a/lib/react_native_util/cli.rb
+++ b/lib/react_native_util/cli.rb
@@ -17,18 +17,36 @@ for more information.
 DESC
 
       command :react_pod do |c|
-        c.syntax = "#{NAME} react_pod [OPTIONS]"
+        c.syntax = "#{NAME} react_pod [OPTIONS]\n    rn react_pod [OPTIONS]"
         c.summary = 'Convert a React Native app to use the React pod from node_modules.'
         c.description = <<DESC
-[Work in progress] Converts a project created with <%= color 'react-native init', BOLD %> to use
-CocoaPods with the React pod from node_modules. This preserves compatibility
-with <%= color 'react-native link', BOLD %>. A converted project will still start the Metro packager
-automatically via a Run Script build phase in the Xcode project. This is an
-alternative to performing manual surgery on a project in Xcode.
+Converts a React Native Xcode project to use the React pod from node_modules
+instead of the projects in the Libraries group. This makes it easier to manage
+native dependencies while preserving compatibility with <%= color 'react-native link', BOLD %>.
+The command looks for your app's package.json in the current directory and
+expects your Xcode project to be located under the ios subdirectory and have
+the name specified for your app in package.json. If a Podfile is found in the
+ios subdirectory, the conversion will fail.
+
+The React.xcodeproj in the Libraries group of a project created by
+<%= color 'react-native init', BOLD %> automatically starts the Metro packager via a Run Script
+build phase. When the react_pod command removes the Libraries group from your
+app project, it adds an equivalent build phase to your app project so that the
+packager will automatically be started when necessary by Xcode.
+
+Use the <%= color '-u', BOLD %> or <%= color '--update', BOLD %> option to update the packager script after
+updating React Native, in case the packager script on the React.xcodeproj changes
+after it's removed from your project.
 DESC
 
-        c.option '-u', '--[no-]update', 'Update a previously converted project (default: convert)'
+        c.option '-u', '--update', 'Update a previously converted project (default: convert)'
         c.option '--[no-]repo-update', 'Update the local podspec repo (default: update; env. var. REACT_NATIVE_UTIL_REPO_UPDATE)'
+
+        c.examples = {
+          'Convert an app project' => 'rn react_pod',
+          'Convert an app project without updating the podspec repo' => 'rn react_pod --no-repo-update',
+          'Update a converted project' => 'rn react_pod -u'
+        }
 
         c.action do |_args, opts|
           begin

--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -122,6 +122,14 @@ module ReactNativeUtil
     def update_project!
       startup!
 
+      unless project.libraries_group.nil?
+        raise ConversionError, "Libraries group present in #{xcodeproj_path}. Conversion necessary. Run rn react_pod without -u."
+      end
+
+      unless File.exist? podfile_path
+        raise ConversionError, "#{podfile_path} not found. Conversion necessary. Run rn react_pod without -u."
+      end
+
       # Check/update the contents of the packager script in React.xcodeproj
       load_react_project!
 
@@ -147,7 +155,7 @@ module ReactNativeUtil
       log " New name    : #{current_script_phase.name}"
 
       current_script_phase.name = new_script_phase.name
-      current_script_phase.shell_script = new_script_phase.shell_script
+      current_script_phase.shell_script = new_script
 
       project.save
 

--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -152,7 +152,7 @@ module ReactNativeUtil
 
       log 'Updating packager phase.'
       log " Current name: #{current_script_phase.name}"
-      log " New name    : #{current_script_phase.name}"
+      log " New name    : #{new_script_phase.name}"
 
       current_script_phase.name = new_script_phase.name
       current_script_phase.shell_script = new_script

--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -144,8 +144,7 @@ module ReactNativeUtil
       # Totally unexpected. Exception. TODO: This is not treated as an error on conversion. Probably should be.
       raise ConversionError, "Packager build phase not found in #{react_project.path}." if new_script_phase.nil?
 
-      new_script = new_script_phase.shell_script
-      new_script.gsub! %r{../scripts}, '../node_modules/react-native/scripts'
+      new_script = new_script_phase.shell_script.gsub %r{../scripts}, '../node_modules/react-native/scripts'
 
       if new_script == current_script_phase.shell_script && new_script_phase.name == current_script_phase.name
         log "#{current_script_phase.name} build phase up to date. ✅"

--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -55,6 +55,106 @@ module ReactNativeUtil
     # @raise ExecutionError on generic command failure
     # @raise Errno::ENOENT if a required command is not present
     def convert_to_react_pod!
+      startup!
+
+      if project.libraries_group.nil?
+        log "Libraries group not found in #{xcodeproj_path}. No conversion necessary."
+        return
+      end
+
+      if File.exist? podfile_path
+        log "Podfile already present at #{File.expand_path podfile_path}.".red.bold
+        log "A future release of #{NAME} may support integration with an existing Podfile."
+        log 'This release can only convert apps that do not currently use a Podfile.'
+        exit 1
+      end
+
+      # Not used at the moment
+      # load_react_podspec!
+
+      # 1. Detect native dependencies in Libraries group.
+      log 'Dependencies:'
+      project.dependencies.each { |d| log " #{d}" }
+
+      # Save for after Libraries removed.
+      deps_to_add = project.dependencies
+
+      # 2. Run react-native unlink for each one.
+      log 'Unlinking dependencies'
+      project.dependencies.each do |dep|
+        run_command_with_spinner! 'react-native', 'unlink', dep, log: File.join(Dir.tmpdir, "react-native-unlink-#{dep}.log")
+      end
+
+      # reload after react-native unlink
+      load_xcodeproj!
+      load_react_project!
+
+      # 3. Add Start Packager script
+      project.add_packager_script_from react_project
+
+      # 4. Generate boilerplate Podfile.
+      generate_podfile!
+
+      # 5. Remove Libraries group from Xcode project.
+      project.remove_libraries_group
+      project.save
+
+      # 6. Run react-native link for each dependency (adds to Podfile).
+      log 'Linking dependencies'
+      deps_to_add.each do |dep|
+        run_command_with_spinner! 'react-native', 'link', dep, log: File.join(Dir.tmpdir, "react-native-link-#{dep}.log")
+      end
+
+      # 7. pod install
+      log "Generating Pods project and ios/#{app_name}.xcworkspace"
+      command = %w[pod install]
+      command << '--repo-update' if options[:repo_update]
+      run_command_with_spinner!(*command, chdir: 'ios', log: File.join(Dir.tmpdir, 'pod-install.log'))
+
+      log 'Conversion complete ✅'
+
+      # 8. Open workspace/build
+      execute 'open', File.join('ios', "#{app_name}.xcworkspace")
+
+      # 9. TODO: SCM/git (add, commit - optional)
+    end
+
+    def update_project!
+      startup!
+
+      # Check/update the contents of the packager script in React.xcodeproj
+      load_react_project!
+
+      current_script_phase = project.packager_phase
+
+      # Not an error. User may have removed it.
+      log "Packager build phase not found in #{xcodeproj_path}. Not updating.".yellow and return if current_script_phase.nil?
+
+      new_script_phase = react_project.packager_phase
+      # Totally unexpected. Exception. TODO: This is not treated as an error on conversion. Probably should be.
+      raise ConversionError, "Packager build phase not found in #{react_project.path}." if new_script_phase.nil?
+
+      new_script = new_script_phase.shell_script
+      new_script.gsub! %r{../scripts}, '../node_modules/react-native/scripts'
+
+      if new_script == current_script_phase.shell_script && new_script_phase.name == current_script_phase.name
+        log "#{current_script_phase.name} build phase up to date. ✅"
+        return
+      end
+
+      log 'Updating packager phase.'
+      log " Current name: #{current_script_phase.name}"
+      log " New name    : #{current_script_phase.name}"
+
+      current_script_phase.name = new_script_phase.name
+      current_script_phase.shell_script = new_script_phase.shell_script
+
+      project.save
+
+      log "Updated #{xcodeproj_path} ✅"
+    end
+
+    def startup!
       validate_commands! REQUIRED_COMMANDS
 
       # Make sure no uncommitted changes
@@ -68,73 +168,12 @@ module ReactNativeUtil
       log 'package.json:'
       log " app name: #{app_name.inspect}"
 
-      # 1. Detect project. TODO: Add an option to override.
+      # Detect project. TODO: Add an option to override.
       @xcodeproj_path = File.expand_path "ios/#{app_name}.xcodeproj"
       load_xcodeproj!
       log "Found Xcode project at #{xcodeproj_path}"
 
-      if project.libraries_group.nil?
-        log "Libraries group not found in #{xcodeproj_path}. No conversion necessary."
-        exit 0
-      end
-
-      if File.exist? podfile_path
-        log "Podfile already present at #{File.expand_path podfile_path}.".red.bold
-        log "A future release of #{NAME} may support integration with an existing Podfile."
-        log 'This release can only convert apps that do not currently use a Podfile.'
-        exit 1
-      end
-
       project.validate_app_target!
-
-      # Not used at the moment
-      # load_react_podspec!
-
-      # 2. Detect native dependencies in Libraries group.
-      log 'Dependencies:'
-      project.dependencies.each { |d| log " #{d}" }
-
-      # Save for after Libraries removed.
-      deps_to_add = project.dependencies
-
-      # 3. Run react-native unlink for each one.
-      log 'Unlinking dependencies'
-      project.dependencies.each do |dep|
-        run_command_with_spinner! 'react-native', 'unlink', dep, log: File.join(Dir.tmpdir, "react-native-unlink-#{dep}.log")
-      end
-
-      # reload after react-native unlink
-      load_xcodeproj!
-      load_react_project!
-
-      # 4. Add Start Packager script
-      project.add_packager_script_from react_project
-
-      # 5. Generate boilerplate Podfile.
-      generate_podfile!
-
-      # 6. Remove Libraries group from Xcode project.
-      project.remove_libraries_group
-      project.save
-
-      # 7. Run react-native link for each dependency (adds to Podfile).
-      log 'Linking dependencies'
-      deps_to_add.each do |dep|
-        run_command_with_spinner! 'react-native', 'link', dep, log: File.join(Dir.tmpdir, "react-native-link-#{dep}.log")
-      end
-
-      # 8. pod install
-      log "Generating Pods project and ios/#{app_name}.xcworkspace"
-      command = %w[pod install]
-      command << '--repo-update' if options[:repo_update]
-      run_command_with_spinner!(*command, chdir: 'ios', log: File.join(Dir.tmpdir, 'pod-install.log'))
-
-      log 'Conversion complete ✅'
-
-      # 9. Open workspace/build
-      execute 'open', File.join('ios', "#{app_name}.xcworkspace")
-
-      # 10. TODO: SCM/git (add, commit - optional)
     end
 
     # Read the contents of ./package.json into @package_json

--- a/lib/react_native_util/converter.rb
+++ b/lib/react_native_util/converter.rb
@@ -130,6 +130,8 @@ module ReactNativeUtil
         raise ConversionError, "#{podfile_path} not found. Conversion necessary. Run rn react_pod without -u."
       end
 
+      log "Updating project at #{xcodeproj_path}"
+
       # Check/update the contents of the packager script in React.xcodeproj
       load_react_project!
 

--- a/lib/react_native_util/core_ext/io.rb
+++ b/lib/react_native_util/core_ext/io.rb
@@ -1,3 +1,4 @@
+require 'colored'
 require 'shellwords'
 require 'time'
 require_relative 'string'

--- a/lib/react_native_util/metadata.rb
+++ b/lib/react_native_util/metadata.rb
@@ -1,7 +1,7 @@
 # Conversion tools for React Native projects
 module ReactNativeUtil
   NAME = 'react_native_util'
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
   SUMMARY = 'Community utility CLI for React Native projects'
   DESCRIPTION = 'Converts a project created with react-native init to use CocoaPods with the ' \
                 'React pod from node_modules. This preserves compatibility with ' \

--- a/lib/react_native_util/rake/react_pod_task.rb
+++ b/lib/react_native_util/rake/react_pod_task.rb
@@ -16,6 +16,7 @@ module ReactNativeUtil
       def initialize(
         name = :react_pod,
         description = 'Convert project to use React pod',
+        update_description = 'Update project',
         chdir: '.',
         repo_update: boolean_env_var?(:REACT_NATIVE_UTIL_REPO_UPDATE, default_value: true)
       )
@@ -27,7 +28,7 @@ module ReactNativeUtil
           end
         end
 
-        desc 'Update project'
+        desc update_description
         task "#{name}:update", %i[path] do |_task, opts|
           project_dir = opts[:path] || chdir
           Dir.chdir project_dir do

--- a/lib/react_native_util/rake/react_pod_task.rb
+++ b/lib/react_native_util/rake/react_pod_task.rb
@@ -17,13 +17,21 @@ module ReactNativeUtil
         name = :react_pod,
         description = 'Convert project to use React pod',
         chdir: '.',
-        repo_update: boolean_env_var?(:REACT_NATIVE_UTIL_REPO_UPDATE)
+        repo_update: boolean_env_var?(:REACT_NATIVE_UTIL_REPO_UPDATE, default_value: true)
       )
         desc description
         task name, %i[path] do |_task, opts|
           project_dir = opts[:path] || chdir
           Dir.chdir project_dir do
             Converter.new(repo_update: repo_update).convert_to_react_pod!
+          end
+        end
+
+        desc 'Update project'
+        task "#{name}:update", %i[path] do |_task, opts|
+          project_dir = opts[:path] || chdir
+          Dir.chdir project_dir do
+            Converter.new(repo_update: repo_update).update_project!
           end
         end
       end

--- a/lib/react_native_util/util.rb
+++ b/lib/react_native_util/util.rb
@@ -1,4 +1,3 @@
-require 'colored'
 require 'tmpdir'
 require 'tty/platform'
 require 'tty/spinner'
@@ -18,15 +17,16 @@ module ReactNativeUtil
     def run_command_with_spinner!(*command, log: nil, chdir: nil)
       STDOUT.flush
       STDERR.flush
+
       spinner = TTY::Spinner.new "[:spinner] #{command.shelljoin}", format: :flip
       spinner.auto_spin
+
       start_time = Time.now
       execute(*command, log: nil, output: log, chdir: chdir)
-      elapsed = Time.now - start_time
-      spinner.success "success in #{format('%.1f', elapsed)} s"
+
+      spinner.success "success in #{elapsed_from start_time} s"
     rescue ExecutionError
-      elapsed = Time.now - start_time
-      spinner.error "failure in #{format('%.1f', elapsed)} s"
+      spinner.error "failure in #{elapsed_from start_time} s"
       STDOUT.log "See #{log} for details." if log && log.kind_of?(String)
       raise
     end
@@ -49,6 +49,10 @@ module ReactNativeUtil
       raise ExecutionError, "#{command.shelljoin}: #{$?}" unless $?.success?
 
       nil
+    end
+
+    def elapsed_from(time)
+      format('%.1f', Time.now - time)
     end
 
     # Return a Boolean value associated with an environment variable.


### PR DESCRIPTION
Added Converter#update_project! and a -u option to the react_pod command, as well as a react_pod:update rake task. This will update the packager script build phase on the app target in a previously converted project to match the build phase from React.xcodeproj in node_modules (no longer used by the converted project).

First run `rake react_pod` and commit the changes.
```
[jdee@Jimmy-Dees-MacBookPro react_native_util (tmp)]$ rake react_pod:update
2019-05-14T14:36:23-07:00 react_native_util react_pod v0.5.0
2019-05-14T14:36:25-07:00  Darwin 18.5.0 x86_64
2019-05-14T14:36:25-07:00  Ruby 2.6.3: ~/.rvm/rubies/ruby-2.6.3/bin/ruby
2019-05-14T14:36:25-07:00  RubyGems 3.0.3: ~/.rvm/rubies/ruby-2.6.3/bin/gem
2019-05-14T14:36:25-07:00  Bundler 2.0.1: ~/.rvm/gems/ruby-2.6.3/bin/bundle
2019-05-14T14:36:25-07:00  react-native-cli: ~/.nvm/versions/node/v10.15.0/bin/react-native
2019-05-14T14:36:25-07:00   react-native-cli: 2.0.1
2019-05-14T14:36:25-07:00   react-native: 0.59.8
2019-05-14T14:36:26-07:00  yarn 1.16.0: /usr/local/bin/yarn
2019-05-14T14:36:26-07:00  cocoapods 1.6.1: ~/.rvm/gems/ruby-2.6.3/bin/pod
2019-05-14T14:36:26-07:00  cocoapods-core: 1.6.1
2019-05-14T14:36:26-07:00 package.json:
2019-05-14T14:36:26-07:00  app name: "TestApp"
2019-05-14T14:36:26-07:00 Found Xcode project at ~/github/jdee/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
2019-05-14T14:36:26-07:00 Updating project at ~/github/jdee/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
2019-05-14T14:36:26-07:00 Start Packager build phase up to date. ✅
```

Then manually modify the script in node_modules/react-native/React/React.xcodeproj:
```
[jdee@Jimmy-Dees-MacBookPro react_native_util (tmp)]$ rake react_pod:update
2019-05-14T14:40:40-07:00 react_native_util react_pod v0.5.0
2019-05-14T14:40:42-07:00  Darwin 18.5.0 x86_64
2019-05-14T14:40:42-07:00  Ruby 2.6.3: ~/.rvm/rubies/ruby-2.6.3/bin/ruby
2019-05-14T14:40:42-07:00  RubyGems 3.0.3: ~/.rvm/rubies/ruby-2.6.3/bin/gem
2019-05-14T14:40:42-07:00  Bundler 2.0.1: ~/.rvm/gems/ruby-2.6.3/bin/bundle
2019-05-14T14:40:42-07:00  react-native-cli: ~/.nvm/versions/node/v10.15.0/bin/react-native
2019-05-14T14:40:42-07:00   react-native-cli: 2.0.1
2019-05-14T14:40:42-07:00   react-native: 0.59.8
2019-05-14T14:40:42-07:00  yarn 1.16.0: /usr/local/bin/yarn
2019-05-14T14:40:43-07:00  cocoapods 1.6.1: ~/.rvm/gems/ruby-2.6.3/bin/pod
2019-05-14T14:40:43-07:00  cocoapods-core: 1.6.1
2019-05-14T14:40:43-07:00 package.json:
2019-05-14T14:40:43-07:00  app name: "TestApp"
2019-05-14T14:40:43-07:00 Found Xcode project at ~/github/jdee/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
2019-05-14T14:40:43-07:00 Updating project at ~/github/jdee/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
2019-05-14T14:40:43-07:00 Updating packager phase.
2019-05-14T14:40:43-07:00  Current name: Start Packager
2019-05-14T14:40:43-07:00  New name    : Start Packager
2019-05-14T14:40:43-07:00 Updated ~/github/jdee/react_native_util/examples/TestApp/ios/TestApp.xcodeproj ✅
```

A separate option may not be the best idea. It might be best to evaluate the necessity for each conversion step and potentially fix a broken project each time the command is run, though this may be more involved.