### PR TITLE
Better app target

### DIFF
--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -32,7 +32,7 @@ module ReactNativeUtil
     end
 
     def test_target
-      targets.select(&:test_target_type?).reject { |t| t.name =~ /tvOS/ }.first
+      targets.select(&:test_target_type?).select { |t| t.platform_name == :ios }.first
     end
 
     # Validate an assumption about the project. TODO: Provide override option.

--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -28,7 +28,7 @@ module ReactNativeUtil
     attr_accessor :app_name
 
     def app_target
-      targets.find { |t| t.name == app_name }
+      targets.find { |t| t.product_type == 'com.apple.product-type.application' }
     end
 
     def test_target
@@ -38,8 +38,7 @@ module ReactNativeUtil
     # Validate an assumption about the project. TODO: Provide override option.
     # @raise ConversionError if an application target is not found with the same name as the project.
     def validate_app_target!
-      raise ConversionError, "Unable to find target #{app_name} in #{path}." if app_target.nil?
-      raise ConversionError, "Target #{app_name} is not an application target." unless app_target.product_type == 'com.apple.product-type.application'
+      raise ConversionError, "Unable to find application target in #{path}." if app_target.nil?
     end
 
     # A representation of the Libraries group (if any) from the Xcode project.

--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -28,7 +28,7 @@ module ReactNativeUtil
     attr_accessor :app_name
 
     def app_target
-      targets.find { |t| t.product_type == 'com.apple.product-type.application' }
+      targets.find { |t| t.platform_name == :ios && t.product_type == 'com.apple.product-type.application' }
     end
 
     def test_target

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -16,7 +16,7 @@ describe ReactNativeUtil::Project do
   end
 
   it 'finds a test target' do
-    dummy_test_target = double 'target', name: 'TestAppTests'
+    dummy_test_target = double 'target', name: 'TestAppTests', platform_name: :ios
     expect(dummy_test_target).to receive(:test_target_type?).at_least(:once) { true }
     expect(project).to receive(:targets) { [dummy_test_target] }
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -7,7 +7,7 @@ describe ReactNativeUtil::Project do
   end
 
   it 'finds an app target' do
-    dummy_app_target = double 'target', name: 'TestApp', product_type: 'com.apple.product-type.application'
+    dummy_app_target = double 'target', platform_name: :ios, product_type: 'com.apple.product-type.application'
     expect(project).to receive(:targets) { [dummy_app_target] }
 
     app_target = project.app_target
@@ -38,7 +38,7 @@ describe ReactNativeUtil::Project do
 
     it 'raises for the wrong #product_type' do
       # Right name, wrong product_type
-      dummy_target = double 'target', name: 'TestApp', product_type: 'foo'
+      dummy_target = double 'target', platform_name: :ios, product_type: 'foo'
       expect(project).to receive(:targets).at_least(:once) { [dummy_target] }
 
       expect do
@@ -47,7 +47,7 @@ describe ReactNativeUtil::Project do
     end
 
     it 'succeeds with the correct name and product type' do
-      dummy_target = double 'target', name: 'TestApp', product_type: 'com.apple.product-type.application'
+      dummy_target = double 'target', platform_name: :ios, product_type: 'com.apple.product-type.application'
       expect(project).to receive(:targets).at_least(:once) { [dummy_target] }
 
       expect do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -7,13 +7,12 @@ describe ReactNativeUtil::Project do
   end
 
   it 'finds an app target' do
-    dummy_app_target = double 'target', name: 'TestApp'
+    dummy_app_target = double 'target', name: 'TestApp', product_type: 'com.apple.product-type.application'
     expect(project).to receive(:targets) { [dummy_app_target] }
 
     app_target = project.app_target
 
     expect(app_target).not_to be_nil
-    expect(app_target.name).to eq 'TestApp'
   end
 
   it 'finds a test target' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -36,17 +36,7 @@ describe ReactNativeUtil::Project do
       end.to raise_error ReactNativeUtil::ConversionError
     end
 
-    it 'raises for the wrong #product_type' do
-      # Right name, wrong product_type
-      dummy_target = double 'target', platform_name: :ios, product_type: 'foo'
-      expect(project).to receive(:targets).at_least(:once) { [dummy_target] }
-
-      expect do
-        project.validate_app_target!
-      end.to raise_error ReactNativeUtil::ConversionError
-    end
-
-    it 'succeeds with the correct name and product type' do
+    it 'succeeds if an app target is found' do
       dummy_target = double 'target', platform_name: :ios, product_type: 'com.apple.product-type.application'
       expect(project).to receive(:targets).at_least(:once) { [dummy_target] }
 


### PR DESCRIPTION
Remove the assumption that the app target has the name of the app. Select iOS targets only for app and test targets.