### PR TITLE
Improve dependency detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,39 +135,52 @@ git status
 
 _Typical command output:_
 ```
-2019-05-14T19:21:36-07:00 react_native_util react_pod v0.5.1
-2019-05-14T19:21:37-07:00  Darwin 18.5.0 x86_64
-2019-05-14T19:21:37-07:00  Ruby 2.6.3: ~/.rvm/rubies/ruby-2.6.3/bin/ruby
-2019-05-14T19:21:37-07:00  RubyGems 3.0.3: ~/.rvm/rubies/ruby-2.6.3/bin/gem
-2019-05-14T19:21:37-07:00  Bundler 2.0.1: ~/.rvm/gems/ruby-2.6.3/bin/bundle
-2019-05-14T19:21:37-07:00  react-native-cli: ~/.nvm/versions/node/v10.15.0/bin/react-native
-2019-05-14T19:21:37-07:00   react-native-cli: 2.0.1
-2019-05-14T19:21:37-07:00   react-native: 0.59.8
-2019-05-14T19:21:38-07:00  yarn 1.16.0: /usr/local/bin/yarn
-2019-05-14T19:21:38-07:00  cocoapods 1.6.1: ~/.rvm/gems/ruby-2.6.3/bin/pod
-2019-05-14T19:21:38-07:00  cocoapods-core: 1.6.1
-2019-05-14T19:21:38-07:00 package.json:
-2019-05-14T19:21:38-07:00  app name: "TestApp"
-2019-05-14T19:21:38-07:00 Found Xcode project at ~/github/$USER/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
-2019-05-14T19:21:38-07:00 Dependencies:
-2019-05-14T19:21:38-07:00  react-native-webview
-2019-05-14T19:21:38-07:00 Unlinking dependencies
+2019-05-15T12:04:44-07:00 react_native_util react_pod v0.5.2
+2019-05-15T12:04:46-07:00  Darwin 18.5.0 x86_64
+2019-05-15T12:04:46-07:00  Ruby 2.6.3: ~/.rvm/rubies/ruby-2.6.3/bin/ruby
+2019-05-15T12:04:46-07:00  RubyGems 3.0.3: ~/.rvm/rubies/ruby-2.6.3/bin/gem
+2019-05-15T12:04:46-07:00  Bundler 2.0.1: ~/.rvm/gems/ruby-2.6.3/bin/bundle
+2019-05-15T12:04:46-07:00  react-native-cli: ~/.nvm/versions/node/v10.15.0/bin/react-native
+2019-05-15T12:04:46-07:00   react-native-cli: 2.0.1
+2019-05-15T12:04:46-07:00   react-native: 0.59.8
+2019-05-15T12:04:46-07:00  yarn 1.16.0: /usr/local/bin/yarn
+2019-05-15T12:04:47-07:00  cocoapods 1.6.1: ~/.rvm/gems/ruby-2.6.3/bin/pod
+2019-05-15T12:04:47-07:00  cocoapods-core: 1.6.1
+2019-05-15T12:04:47-07:00 package.json:
+2019-05-15T12:04:47-07:00  app name: "TestApp"
+2019-05-15T12:04:47-07:00 Found Xcode project at ~/github/$USER/react_native_util/examples/TestApp/ios/TestApp.xcodeproj
+2019-05-15T12:04:47-07:00 Dependencies:
+2019-05-15T12:04:47-07:00  react-native-webview
+2019-05-15T12:04:47-07:00 Unlinking dependencies
 [✔] react-native unlink react-native-webview success in 0.5 s
-2019-05-14T19:21:39-07:00 Generating ios/Podfile
-2019-05-14T19:21:39-07:00 Removing Libraries from TestApp
-2019-05-14T19:21:39-07:00 Removing Libraries from TestAppTests
-2019-05-14T19:21:39-07:00 Removing Libraries group
-2019-05-14T19:21:39-07:00 Linking dependencies
-[✔] react-native link react-native-webview success in 0.5 s
-2019-05-14T19:21:40-07:00 Generating Pods project and ios/TestApp.xcworkspace
-2019-05-14T19:21:40-07:00 Once pod install is complete, your project will be part of this workspace.
-2019-05-14T19:21:40-07:00 From now on, you should build the workspace with Xcode instead of the project.
-2019-05-14T19:21:40-07:00 Always add the workspace and Podfile.lock to SCM.
-2019-05-14T19:21:40-07:00 It is common practice also to add the Pods directory.
-2019-05-14T19:21:40-07:00 The workspace will be automatically opened when pod install completes.
-[✔] pod install success in 8.6 s
-2019-05-14T19:21:48-07:00 Conversion complete ✅
-2019-05-14T19:21:48-07:00 $ open ios/TestApp.xcworkspace
+2019-05-15T12:04:47-07:00 Generating ios/Podfile
+2019-05-15T12:04:47-07:00 Removing Libraries from TestApp
+2019-05-15T12:04:47-07:00  Removing libRCTBlob.a
+2019-05-15T12:04:47-07:00  Removing libRCTAnimation.a
+2019-05-15T12:04:47-07:00  Removing libReact.a
+2019-05-15T12:04:47-07:00  Removing libRCTActionSheet.a
+2019-05-15T12:04:47-07:00  Removing libRCTGeolocation.a
+2019-05-15T12:04:47-07:00  Removing libRCTImage.a
+2019-05-15T12:04:47-07:00  Removing libRCTLinking.a
+2019-05-15T12:04:47-07:00  Removing libRCTNetwork.a
+2019-05-15T12:04:47-07:00  Removing libRCTSettings.a
+2019-05-15T12:04:47-07:00  Removing libRCTText.a
+2019-05-15T12:04:47-07:00  Removing libRCTVibration.a
+2019-05-15T12:04:47-07:00  Removing libRCTWebSocket.a
+2019-05-15T12:04:47-07:00 Removing Libraries from TestAppTests
+2019-05-15T12:04:47-07:00  Removing libReact.a
+2019-05-15T12:04:47-07:00 Removing Libraries group
+2019-05-15T12:04:47-07:00 Linking dependencies
+[✔] react-native link react-native-webview success in 0.6 s
+2019-05-15T12:04:48-07:00 Generating Pods project and ios/TestApp.xcworkspace
+2019-05-15T12:04:48-07:00 Once pod install is complete, your project will be part of this workspace.
+2019-05-15T12:04:48-07:00 From now on, you should build the workspace with Xcode instead of the project.
+2019-05-15T12:04:48-07:00 Always add the workspace and Podfile.lock to SCM.
+2019-05-15T12:04:48-07:00 It is common practice also to add the Pods directory.
+2019-05-15T12:04:48-07:00 The workspace will be automatically opened when pod install completes.
+[✔] pod install success in 9.2 s
+2019-05-15T12:04:57-07:00 Conversion complete ✅
+2019-05-15T12:04:57-07:00 $ open ios/TestApp.xcworkspace
 ```
 
 ## Convert your own app with Rake
@@ -237,3 +250,7 @@ end
 
 Hosted [Yard](https://yardoc.org) documentation available at
 https://www.rubydoc.info/gems/react_native_util.
+
+## Successfully converted apps:
+
+- https://github.com/azhavrid/movie-swiper

--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -56,6 +56,11 @@ module ReactNativeUtil
         remove_libraries_from_target t
       end
 
+      unless libraries_group.children.empty?
+        log 'Not removing Libraries group. Not empty.'
+        return
+      end
+
       log 'Removing Libraries group'
       libraries_group.remove_from_project
     end

--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -66,7 +66,6 @@ module ReactNativeUtil
     end
 
     def remove_libraries_from_target(target)
-      log "Removing Libraries from #{target.name}"
       to_remove = target.frameworks_build_phase.files.select do |file|
         path = file.file_ref.pretty_print
         next false unless /^lib(.+)\.a$/.match?(path)
@@ -74,6 +73,7 @@ module ReactNativeUtil
         static_libs.include?(path)
       end
 
+      log "Removing Libraries from #{target.name}" unless to_remove.empty?
       to_remove.each { |f| target.frameworks_build_phase.remove_build_file f }
     end
 

--- a/lib/react_native_util/project.rb
+++ b/lib/react_native_util/project.rb
@@ -75,8 +75,8 @@ module ReactNativeUtil
 
       log "Removing Libraries from #{target.name}" unless to_remove.empty?
       to_remove.each do |f|
+        log " Removing #{f.file_ref.pretty_print}"
         target.frameworks_build_phase.remove_build_file f
-        log " Removed #{f.file_ref.pretty_print}"
       end
     end
 


### PR DESCRIPTION
Look for native dependencies from the Libraries group under node_modules. Ignore anything not under node_modules. Package name is the first path component under node_modules. Only remove the Libraries group if it's really empty at the end. Log each individual static lib from Libraries removed from each target.

With this change, successfully converted this app:

https://github.com/azhavrid/movie-swiper